### PR TITLE
Add module_param

### DIFF
--- a/brutal.c
+++ b/brutal.c
@@ -2,8 +2,8 @@
 #include <net/tcp.h>
 #include <net/transp_v6.h>
 
-#define INIT_PACING_RATE 125000 // 1 Mbps
-#define INIT_CWND_GAIN 20
+static int init_pacing_rate = 125000; // 1 Mbps
+static int init_cwnd_gain = 20;
 
 #define MIN_PACING_RATE 62500 // 500 Kbps
 #define MIN_CWND_GAIN 5
@@ -15,6 +15,11 @@
 #define MIN_ACK_RATE 0.8
 
 #define TCP_BRUTAL_PARAMS 23301
+
+module_param(init_pacing_rate, int, 0644);
+MODULE_PARM_DESC(init_pacing_rate, "pacing rate");
+module_param(init_cwnd_gain, int, 0644);
+MODULE_PARM_DESC(init_cwnd_gain, "cwnd gain");
 
 struct brutal_pkt_info
 {
@@ -110,8 +115,8 @@ static void brutal_init(struct sock *sk)
 
     tp->snd_ssthresh = TCP_INFINITE_SSTHRESH;
 
-    brutal->rate = INIT_PACING_RATE;
-    brutal->cwnd_gain = INIT_CWND_GAIN;
+    brutal->rate = init_pacing_rate;
+    brutal->cwnd_gain = init_cwnd_gain;
 
     memset(brutal->slots, 0, sizeof(brutal->slots));
 


### PR DESCRIPTION
So that we could control pacing rate through  `echo number > /sys/module/brutal/parameters/init_pacing_rate`, not just `setsockopt`