### PR TITLE
use div_u64() to let it build on 32-bit, issues#14

### DIFF
--- a/brutal.c
+++ b/brutal.c
@@ -243,7 +243,7 @@ static void brutal_main(struct sock *sk, const struct rate_sample *rs)
         return;
 
     sec = tcp_sock_get_sec(tp);
-    slot = sec % PKT_INFO_SLOTS;
+    div_u64_rem(sec, PKT_INFO_SLOTS, &slot);
 
     if (brutal->slots[slot].sec == sec)
     {

--- a/brutal.c
+++ b/brutal.c
@@ -1,6 +1,7 @@
 #include <linux/module.h>
 #include <linux/version.h>
 #include <net/tcp.h>
+#include <linux/math64.h>
 
 #if IS_ENABLED(CONFIG_IPV6) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
 #include <net/transp_v6.h>
@@ -36,19 +37,19 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
 u64 tcp_sock_get_sec(const struct tcp_sock *tp)
 {
-    return tp->tcp_mstamp / USEC_PER_SEC;
+    return div_u64(tp->tcp_mstamp, USEC_PER_SEC);
 }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 // see https://github.com/torvalds/linux/commit/9a568de4818dea9a05af141046bd3e589245ab83
 u64 tcp_sock_get_sec(const struct tcp_sock *tp)
 {
-    return tp->tcp_mstamp.stamp_us / USEC_PER_SEC;
+    return div_u64(tp->tcp_mstamp.stamp_us, USEC_PER_SEC);
 }
 #else
 #include <linux/jiffies.h>
 u64 tcp_sock_get_sec(const struct tcp_sock *tp)
 {
-    return jiffies_to_usecs(tcp_time_stamp) / USEC_PER_SEC;
+    return div_u64(jiffies_to_usecs(tcp_time_stamp), USEC_PER_SEC);
 }
 #endif
 
@@ -214,10 +215,10 @@ static void brutal_update_rate(struct sock *sk)
     }
 
     rate *= 100;
-    rate /= ack_rate;
+    rate = div_u64(rate, ack_rate);
 
     // The order here is chosen carefully to avoid overflow as much as possible
-    cwnd = rate / MSEC_PER_SEC;
+    cwnd = div_u64(rate, MSEC_PER_SEC);
     cwnd *= rtt_ms;
     cwnd /= mss;
     cwnd *= brutal->cwnd_gain;


### PR DESCRIPTION
[issues#14](https://github.com/apernet/tcp-brutal/issues/14)