### PR TITLE
Fix signature change of tcp_congestion_ops.cong_control on kernel v6.10

### DIFF
--- a/brutal.c
+++ b/brutal.c
@@ -35,19 +35,19 @@
 #define TCP_BRUTAL_PARAMS 23301
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
-u64 tcp_sock_get_sec(const struct tcp_sock *tp)
+static u64 tcp_sock_get_sec(const struct tcp_sock *tp)
 {
     return div_u64(tp->tcp_mstamp, USEC_PER_SEC);
 }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 // see https://github.com/torvalds/linux/commit/9a568de4818dea9a05af141046bd3e589245ab83
-u64 tcp_sock_get_sec(const struct tcp_sock *tp)
+static u64 tcp_sock_get_sec(const struct tcp_sock *tp)
 {
     return div_u64(tp->tcp_mstamp.stamp_us, USEC_PER_SEC);
 }
 #else
 #include <linux/jiffies.h>
-u64 tcp_sock_get_sec(const struct tcp_sock *tp)
+static u64 tcp_sock_get_sec(const struct tcp_sock *tp)
 {
     return div_u64(jiffies_to_usecs(tcp_time_stamp), USEC_PER_SEC);
 }

--- a/brutal.c
+++ b/brutal.c
@@ -230,7 +230,11 @@ static void brutal_update_rate(struct sock *sk)
     WRITE_ONCE(sk->sk_pacing_rate, min_t(u64, rate, READ_ONCE(sk->sk_max_pacing_rate)));
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+static void brutal_main(struct sock *sk, u32 ack, int flag, const struct rate_sample *rs)
+#else
 static void brutal_main(struct sock *sk, const struct rate_sample *rs)
+#endif
 {
     struct tcp_sock *tp = tcp_sk(sk);
     struct brutal *brutal = inet_csk_ca(sk);


### PR DESCRIPTION
fix: #22
ref: https://github.com/torvalds/linux/commit/57bfc7605ca5b102ba336779ae9adbc5bbba1d96